### PR TITLE
Syntax fixes for promql (number and recording rules)

### DIFF
--- a/promeditor/src/QueryField.js
+++ b/promeditor/src/QueryField.js
@@ -23,7 +23,7 @@ const TYPEAHEAD_DEBOUNCE = 300;
 function configurePrismMetricsTokens(metrics) {
   Prism.languages.promql.metric = {
     alias: 'variable',
-    pattern: new RegExp(`\\b(${metrics.join('|')})\\b`, 'i'),
+    pattern: new RegExp(`(${metrics.join('|')})`, 'i'),
   };
 }
 

--- a/promeditor/src/slate-plugins/prism/promql.js
+++ b/promeditor/src/slate-plugins/prism/promql.js
@@ -73,7 +73,7 @@ export const FUNCTIONS = [
 ];
 
 const tokenizer = {
-  'comment': {
+  comment: {
     pattern: /(^|[^\n])#.*/,
     lookbehind: true,
   },
@@ -85,7 +85,7 @@ const tokenizer = {
         pattern: /[^,\s][^,]*[^,\s]*/,
         alias: 'attr-name',
       },
-    }
+    },
   },
   'context-labels': {
     pattern: /\{[^}]*(?=})/,
@@ -99,30 +99,38 @@ const tokenizer = {
         greedy: true,
         alias: 'attr-value',
       },
-    }
+    },
   },
-  'function': new RegExp(`\\b(?:${FUNCTIONS.join('|')})(?=\\s*\\()`, 'i'),
-  'context-range': [{
-    pattern: /\[[^\]]*(?=])/, // [1m]
-    inside: {
-      'range-duration': {
-        pattern: /\b\d+[smhdwy]\b/i,
-        alias: 'number',
-      }
-    }
-  }, {
-    pattern: /(offset\s+)\w+/, // offset 1m
-    lookbehind: true,
-    inside: {
-      'range-duration': {
-        pattern: /\b\d+[smhdwy]\b/i,
-        alias: 'number',
-      }
-    }
-  }],
-  'number': /-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
-  'operator': new RegExp(`/[-+*/=%^~]|&&?|\\|?\\||!=?|<(?:=>?|<|>)?|>[>=]?|\\b(?:${OPERATORS.join('|')})\\b`, 'i'),
-  'punctuation': /[{};()`,.]/
-}
+  function: new RegExp(`\\b(?:${FUNCTIONS.join('|')})(?=\\s*\\()`, 'i'),
+  'context-range': [
+    {
+      pattern: /\[[^\]]*(?=])/, // [1m]
+      inside: {
+        'range-duration': {
+          pattern: /\b\d+[smhdwy]\b/i,
+          alias: 'number',
+        },
+      },
+    },
+    {
+      pattern: /(offset\s+)\w+/, // offset 1m
+      lookbehind: true,
+      inside: {
+        'range-duration': {
+          pattern: /\b\d+[smhdwy]\b/i,
+          alias: 'number',
+        },
+      },
+    },
+  ],
+  number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
+  operator: new RegExp(
+    `/[-+*/=%^~]|&&?|\\|?\\||!=?|<(?:=>?|<|>)?|>[>=]?|\\b(?:${OPERATORS.join(
+      '|'
+    )})\\b`,
+    'i'
+  ),
+  punctuation: /[{};()`,.]/,
+};
 
 export default tokenizer;


### PR DESCRIPTION
* numbers need a boundary, otherwise node_load1 wont match
* removed word boundary requirement for metric to allow rec rules to
 match