### PR TITLE
Close auto-parens before next whitespace

### DIFF
--- a/promeditor/src/slate-plugins/braces.js
+++ b/promeditor/src/slate-plugins/braces.js
@@ -26,8 +26,10 @@ export default function BracesPlugin() {
 
         case '(': {
           event.preventDefault();
-          const length = value.anchorText.text.length;
+          const text = value.anchorText.text;
           const offset = value.anchorOffset;
+          const space = text.indexOf(' ', offset);
+          const length = space > 0 ? space : text.length;
           const forward = length - offset;
           // Insert matching braces
           change

--- a/promeditor/src/slate-plugins/braces.test.js
+++ b/promeditor/src/slate-plugins/braces.test.js
@@ -1,0 +1,41 @@
+import Plain from 'slate-plain-serializer';
+
+import BracesPlugin from './braces';
+
+describe('braces', () => {
+  const handler = BracesPlugin().onKeyDown;
+
+  it('adds closing braces around empty value', () => {
+    const change = Plain.deserialize('').change();
+    const event = new window.KeyboardEvent('keydown', { key: '(' });
+    handler(event, change);
+    expect(Plain.serialize(change.value)).toEqual('()');
+  });
+
+  it('adds closing braces around a value', () => {
+    const change = Plain.deserialize('foo').change();
+    const event = new window.KeyboardEvent('keydown', { key: '(' });
+    handler(event, change);
+    expect(Plain.serialize(change.value)).toEqual('(foo)');
+  });
+
+  it('adds closing braces around the following value only', () => {
+    const change = Plain.deserialize('foo bar ugh').change();
+    let event;
+    event = new window.KeyboardEvent('keydown', { key: '(' });
+    handler(event, change);
+    expect(Plain.serialize(change.value)).toEqual('(foo) bar ugh');
+
+    // Wrap bar
+    change.move(5);
+    event = new window.KeyboardEvent('keydown', { key: '(' });
+    handler(event, change);
+    expect(Plain.serialize(change.value)).toEqual('(foo) (bar) ugh');
+
+    // Create empty parens after (bar)
+    change.move(4);
+    event = new window.KeyboardEvent('keydown', { key: '(' });
+    handler(event, change);
+    expect(Plain.serialize(change.value)).toEqual('(foo) (bar)() ugh');
+  });
+});


### PR DESCRIPTION
* helps with `sum()` for expressions that to vector math
* added tests for slate plugin 🎉 

Fixes #6