### PR TITLE
make --web.route-prefix configurable

### DIFF
--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -67,7 +67,7 @@ default_theme = light
 
   grafana_deployment:
     deployment.new("grafana", 1, [$.grafana_container]) +
-    $.grafana_add_datasource("prometheus", "http://prometheus.%s.svc.cluster.local%s" % [$._config.namespace, $._config.prometheus_path]) +
+    $.grafana_add_datasource("prometheus", "http://prometheus.%s.svc.cluster.local%s" % [$._config.namespace, $._config.prometheus_web_route_prefix]) +
     $.util.configVolumeMount("grafana-config", "/etc/grafana") +
     $.util.configVolumeMount("dashboards", "/grafana/dashboards"),
 

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -5,7 +5,7 @@ k {
     prometheus_external_hostname: "http://prometheus.%s.svc.cluster.local" % $._config.namespace,
     prometheus_path: "/",
     prometheus_port: 80,
-    prometheus_web_route_prefix: "/",
+    prometheus_web_route_prefix: $._config.prometheus_path,
   },
 
   local policyRule = $.rbac.v1beta1.policyRule,
@@ -42,7 +42,7 @@ k {
     container.withArgs([
       "-v", "-t", "-p=/etc/prometheus",
       "curl", "-X", "POST", "--fail", "-o", "-", "-sS",
-      "http://localhost:%s/-/reload" % [$._config.prometheus_port],
+      "http://localhost:%s%s-/reload" % [$._config.prometheus_port, $._config.prometheus_web_route_prefix],
     ]),
 
   local deployment = $.apps.v1beta1.deployment,

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -5,6 +5,7 @@ k {
     prometheus_external_hostname: "http://prometheus.%s.svc.cluster.local" % $._config.namespace,
     prometheus_path: "/",
     prometheus_port: 80,
+    prometheus_web_route_prefix: "/",
   },
 
   local policyRule = $.rbac.v1beta1.policyRule,
@@ -31,6 +32,7 @@ k {
       "--web.listen-address=:%s" % $._config.prometheus_port,
       "--web.external-url=%s%s" % [$._config.prometheus_external_hostname, $._config.prometheus_path],
       "--web.enable-lifecycle",
+      "--web.route-prefix=%s" % $._config.prometheus_web_route_prefix,
     ]) +
     $.util.resourcesRequests("250m", "1536Mi") +
     $.util.resourcesLimits("500m", "2Gi"),
@@ -40,7 +42,7 @@ k {
     container.withArgs([
       "-v", "-t", "-p=/etc/prometheus",
       "curl", "-X", "POST", "--fail", "-o", "-", "-sS",
-      "http://localhost:%s%s-/reload" % [$._config.prometheus_port, $._config.prometheus_path],
+      "http://localhost:%s/-/reload" % [$._config.prometheus_port],
     ]),
 
   local deployment = $.apps.v1beta1.deployment,

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -53,7 +53,7 @@ k {
       $.prometheus_watch_container,
     ]) +
     $.util.configVolumeMount("prometheus-config", "/etc/prometheus") +
-    deployment.mixin.spec.template.metadata.withAnnotations({ "prometheus.io.path": "%smetrics" % $._config.prometheus_path }) +
+    deployment.mixin.spec.template.metadata.withAnnotations({ "prometheus.io.path": "%smetrics" % $._config.prometheus_web_route_prefix }) +
     deployment.mixin.spec.template.spec.withServiceAccount("prometheus") +
     deployment.mixin.spec.template.spec.securityContext.withRunAsUser(0),
 


### PR DESCRIPTION
In order to be able to use prometheus via kubectl proxy you need to configure
the `web.route-prefix`.

Example:
```
prometheus_external_hostname: "http://localhost:8001",
prometheus_path: "/api/v1/namespaces/default/services/prometheus:80/proxy/",
prometheus_web_route_prefix: "/",
```