### PR TITLE
klumps: fix recording rule record name, namespace_name

### DIFF
--- a/klumps/recording_rules.jsonnet
+++ b/klumps/recording_rules.jsonnet
@@ -12,13 +12,13 @@
       name: "k8s.rules",
       rules: [
         {
-          record: "namespace:container_cpu_usage_seconds_total:sum_rate",
+          record: "namespace_name:container_cpu_usage_seconds_total:sum_rate",
           expr: |||
             sum(rate(container_cpu_usage_seconds_total{job="%(cadvisor)s",image!=""}[5m])) by (namespace)
           ||| % $._config.jobs,
         },
         {
-          record: "namespace:container_memory_usage_bytes:sum",
+          record: "namespace_name:container_memory_usage_bytes:sum",
           expr: |||
             sum(container_memory_usage_bytes{job="%(cadvisor)s",image!=""}) by (namespace)
           ||| % $._config.jobs,


### PR DESCRIPTION
The record name prefix "namespace" does not match with the prefix used in other records in the same set "namespace_name" . Additionally, in the Grafana dashboards "namespace_name" is used instead of "namespace". I guess this was a simple typo.