### PR TITLE
Various updated to make this work for Grapeshot.

### DIFF
--- a/klumps/alerts.jsonnet
+++ b/klumps/alerts.jsonnet
@@ -23,8 +23,8 @@
         },
         {
           expr: |||
-            kube_pod_status_ready{condition="true"} != 1
-          |||,
+            sum by (namespace, pod) (kube_pod_status_phase{job="%(kube_state_metrics)s", phase!~"Running|Succeeded"}) > 0
+          ||| % $.jobs,
           labels: {
             severity: "critical",
           },

--- a/klumps/alerts.jsonnet
+++ b/klumps/alerts.jsonnet
@@ -1,4 +1,9 @@
 {
+  jobs+:: {
+    kube_dns: "kube-system/kube-dns",
+    kube_state_metrics: "default/kube-state-metrics",
+  },
+
   groups+: [
     {
       name: "kubernetes",
@@ -101,6 +106,45 @@
           },
           "for": "5m",
           alert: "KubeMemOvercommit",
+        },
+        {
+          alert: "KubeVersionMismatch",
+          expr: |||
+            count(count(kubernetes_build_info{job!~"%s"}) by (gitVersion)) > 1
+          ||| % $.jobs.kube_dns,
+          "for": "1h",
+          labels: {
+            severity: "warning",
+          },
+          annotations: {
+            message: "There are {{ $value }} different versions of Kubernetes components running.",
+          },
+        },
+        {
+          alert: "KubeClientErrors",
+          expr: |||
+           sum(rate(rest_client_requests_total{code!~"2.."}[5m])) by (instance, job) * 100 / sum(rate(rest_client_requests_total[5m])) by (instance, job) > 1
+          |||,
+          "for": "15m",
+          labels: {
+            severity: "warning",
+          },
+          annotations: {
+            message: "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }}% errors.'",
+          },
+        },
+        {
+          alert: "KubeClientErrors",
+          expr: |||
+           sum(rate(ksm_scrape_error_total{job="%s"}[5m])) by (instance, job) > 0.1
+          ||| % $.jobs.kube_state_metrics,
+          "for": "15m",
+          labels: {
+            severity: "warning",
+          },
+          annotations: {
+            message: "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }} errors / sec.'",
+          },
         },
       ],
     },

--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -2,7 +2,7 @@
   _images+:: {
     prometheus: "prom/prometheus:v2.2.1",
     watch: "weaveworks/watch:master-5b2a6e5",
-    kubeStateMetrics: "gcr.io/google_containers/kube-state-metrics:v0.5.0",
+    kubeStateMetrics: "gcr.io/google_containers/kube-state-metrics:v1.2.0",
     grafana: "kausal/grafana:v4.6.2-plus-build-image-c3b097cfc",
     gfdatasource: "quay.io/weaveworks/gfdatasource:master-2bda599",
     alertmanager: "prom/alertmanager:v0.14.0",

--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -44,7 +44,11 @@ k {
       "--config.file=/etc/alertmanager/alertmanager.yml",
       "--web.listen-address=:%s" % $._config.alertmanager_port,
       "--web.external-url=%s%s" % [$._config.alertmanager_external_hostname, $._config.alertmanager_path],
-    ]),
+    ]) +
+    container.mixin.resources.withRequests({
+      cpu: "10m",
+      memory: "40Mi",
+    }),
 
   alertmanager_watch_container::
     container.new("watch", $._images.watch) +
@@ -52,7 +56,11 @@ k {
       "-v", "-t", "-p=/etc/alertmanager",
       "curl", "-X", "POST", "--fail", "-o", "-", "-sS",
       "http://localhost:%s%s-/reload" % [$._config.alertmanager_port, $._config.alertmanager_path],
-    ]),
+    ]) +
+    container.mixin.resources.withRequests({
+      cpu: "10m",
+      memory: "20Mi",
+    }),
 
   local deployment = $.apps.v1beta1.deployment,
 

--- a/prometheus-ksonnet/lib/kausal.libsonnet
+++ b/prometheus-ksonnet/lib/kausal.libsonnet
@@ -96,7 +96,7 @@ k {
     },
   },
 
-  util:: {
+  util+:: {
     // serviceFor create service for a given deployment.
     serviceFor(deployment)::
       local container = $.core.v1.container;

--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -8,21 +8,66 @@ k {
     $.util.rbac("kube-state-metrics", [
       policyRule.new() +
       policyRule.withApiGroups([""]) +
-      policyRule.withResources(["nodes", "pods", "services", "resourcequotas", "replicationcontrollers", "limitranges"]) +
+      policyRule.withResources([
+        "nodes",
+        "pods",
+        "services",
+        "resourcequotas",
+        "replicationcontrollers",
+        "limitranges",
+        "persistentvolumeclaims",
+        "persistentvolumes",
+        "namespaces",
+        "endpoints",
+      ]) +
       policyRule.withVerbs(["list", "watch"]),
 
       policyRule.new() +
       policyRule.withApiGroups(["extensions"]) +
-      policyRule.withResources(["daemonsets", "deployments", "replicasets"]) +
+      policyRule.withResources([
+        "daemonsets",
+        "deployments",
+        "replicasets",
+      ]) +
+      policyRule.withVerbs(["list", "watch"]),
+
+      policyRule.new() +
+      policyRule.withApiGroups(["apps"]) +
+      policyRule.withResources([
+        "statefulsets",
+      ]) +
+      policyRule.withVerbs(["list", "watch"]),
+
+      policyRule.new() +
+      policyRule.withApiGroups(["batch"]) +
+      policyRule.withResources([
+        "cronjobs",
+        "jobs",
+      ]) +
+      policyRule.withVerbs(["list", "watch"]),
+
+      policyRule.new() +
+      policyRule.withApiGroups(["autoscaling"]) +
+      policyRule.withResources([
+        "horizontalpodautoscalers",
+      ]) +
       policyRule.withVerbs(["list", "watch"]),
     ]),
 
   local container = $.core.v1.container,
+  local containerPort = $.core.v1.containerPort,
 
   kube_state_metrics_container::
     container.new("kube-state-metrics", $._images.kubeStateMetrics) +
-    container.withPorts($.core.v1.containerPort.new("http-metrics", 80)) +
-    container.withArgs(["--port=80"]) +
+    container.withArgs([
+      "--port=80",
+      "--telemetry-host=0.0.0.0",
+      "--telemetry-port=81",
+    ]) +
+    container.withPorts([
+      containerPort.new("http-metrics", 80),
+      containerPort.new("self-metrics", 81),
+    ]) +
     $.util.resourcesRequests("25m", "20Mi") +
     $.util.resourcesLimits("50m", "40Mi"),
 

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -1,6 +1,10 @@
 local k = import "kausal.libsonnet";
 
 k {
+  _config+:: {
+    cluster_dns_suffix: "cluster.local",
+  },
+
   local configMap = $.core.v1.configMap,
 
   nginx_config_map:
@@ -24,17 +28,17 @@ k {
           access_log   /dev/stderr  main;
           sendfile     on;
           tcp_nopush   on;
-          resolver     kube-dns.kube-system.svc.cluster.local;
+          resolver     kube-dns.kube-system.svc.%(cluster_dns_suffix)s;
           server {
             listen 80;
             location ~ ^/prometheus(/?)(.*)$ {
-              proxy_pass      http://prometheus.%(namespace)s.svc.cluster.local/prometheus/$2$is_args$args;
+              proxy_pass      http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s/prometheus/$2$is_args$args;
             }
             location ~ /alertmanager(/?)(.*)$ {
-              proxy_pass      http://alertmanager.%(namespace)s.svc.cluster.local/alertmanager/$2$is_args$args;
+              proxy_pass      http://alertmanager.%(namespace)s.svc.%(cluster_dns_suffix)s/alertmanager/$2$is_args$args;
             }
             location ~ ^/grafana(/?)(.*)$ {
-              proxy_pass      http://grafana.%(namespace)s.svc.cluster.local/$2$is_args$args;
+              proxy_pass      http://grafana.%(namespace)s.svc.%(cluster_dns_suffix)s/$2$is_args$args;
             }
             location ~ /(index.html)? {
               root /etc/nginx;

--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -21,7 +21,7 @@ k {
 
   local daemonSet = $.extensions.v1beta1.daemonSet,
 
-  node_exporter_deamonset:
+  node_exporter_daemonset:
     daemonSet.new("node-exporter", [$.node_exporter_container]) +
     daemonSet.mixin.spec.template.spec.withHostPid(true) +
     daemonSet.mixin.spec.template.spec.withHostNetwork(true) +

--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -1,6 +1,10 @@
 local k = import "kausal.libsonnet";
 
 k {
+  _config+::{
+    node_exporter_mount_root: true,
+  },
+
   local container = $.core.v1.container,
 
   node_exporter_container::
@@ -23,5 +27,7 @@ k {
     daemonSet.mixin.spec.template.spec.withHostNetwork(true) +
     $.util.hostVolumeMount("proc", "/proc", "/host/proc") +
     $.util.hostVolumeMount("sys", "/sys", "/host/sys") +
-    $.util.hostVolumeMount("root", "/", "/rootfs"),
+      (if $._config.node_exporter_mount_root
+      then $.util.hostVolumeMount("root", "/", "/rootfs")
+      else {}),
 }


### PR DESCRIPTION
- a couple more useful kubernetes alerts.
- update kube-state-metrics.
- make nginx work on clusters without the cluster.local name.
- make mounting root fs in node exporter optional.