### PR TITLE
run node-exporter as root

### DIFF
--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -16,6 +16,7 @@ k {
       "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($|/)",
     ]) +
     container.mixin.securityContext.withPrivileged(true) +
+    container.mixin.securityContext.withRunAsUser(0) +
     $.util.resourcesRequests("10m", "20Mi") +
     $.util.resourcesLimits("20m", "40Mi"),
 


### PR DESCRIPTION
This fixes

```
Error on statfs() system call for "/rootfs/var/lib/kubelet/pods/XXXXX/volumes/XXXXXXX": permission denied"
```
on newer kernel versions.