### PR TITLE
Update to Grafana v5.

### DIFF
--- a/klumps/lib/grafana.libsonnet
+++ b/klumps/lib/grafana.libsonnet
@@ -45,7 +45,6 @@
       list: [],
     },
     hideControls: false,
-    id: 1,
     links: [],
     rows: [],
     schemaVersion: 14,

--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -3,7 +3,7 @@
     prometheus: "prom/prometheus:v2.2.1",
     watch: "weaveworks/watch:master-5b2a6e5",
     kubeStateMetrics: "gcr.io/google_containers/kube-state-metrics:v1.2.0",
-    grafana: "kausal/grafana:v4.6.2-plus-build-image-760716341",
+    grafana: "grafana/grafana:5.0.4",
     gfdatasource: "quay.io/weaveworks/gfdatasource:master-2bda599",
     alertmanager: "prom/alertmanager:v0.14.0",
     nodeExporter: "prom/node-exporter:v0.15.1",

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -75,6 +75,25 @@ default_theme = light
       }),
     }),
 
+  grafana_add_datasource_with_basicauth(name, url, username, password, default=false)::
+    configMap.withDataMixin({
+      ["%s.yml" % name]: k.util.manifestYaml({
+        apiVersion: 1,
+        datasources: [{
+          name: name,
+          type: "prometheus",
+          access: "proxy",
+          url: url,
+          isDefault: default,
+          version: 1,
+          editable: false,
+          basicAuth: true,
+          basicAuthUser: username,
+          basicAuthPassword: password,
+        }],
+      }),
+    }),
+
   local container = $.core.v1.container,
 
   grafana_container::

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -13,10 +13,6 @@ k {
 enabled = true
 org_role = Admin
 
-[dashboards.json]
-enabled = true
-path = /grafana/dashboards
-
 [server]
 http_port = 80
 root_url = %(grafana_root_url)s
@@ -39,6 +35,46 @@ default_theme = light
     configMap.withData({ [name]: std.toString($.dashboards[name])
                          for name in std.objectFields($.dashboards) }),
 
+  grafana_dashboard_provisioning_config_map:
+    configMap.new("grafana-dashboard-provisioning") +
+    configMap.withData({"dashboards.yml": k.util.manifestYaml({
+      apiVersion: 1,
+      providers: [{
+        name: "dashboards",
+        orgId: 1,
+        folder: "",
+        type: "file",
+        disableDeletion: true,
+        editable: false,
+        options: {
+          path: "/grafana/dashboards",
+        },
+      }],
+    }),
+  }),
+
+  grafana_datasource_config_map:
+    configMap.new("grafana-datasources") +
+    $.grafana_add_datasource("prometheus",
+      "http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s" % $._config,
+      default=true),
+
+  grafana_add_datasource(name, url, default=false)::
+    configMap.withDataMixin({
+      ["%s.yml" % name]: k.util.manifestYaml({
+        apiVersion: 1,
+        datasources: [{
+          name: name,
+          type: "prometheus",
+          access: "proxy",
+          url: url,
+          isDefault: default,
+          version: 1,
+          editable: false,
+        }],
+      }),
+    }),
+
   local container = $.core.v1.container,
 
   grafana_container::
@@ -53,22 +89,11 @@ default_theme = light
 
   local deployment = $.apps.v1beta1.deployment,
 
-  grafana_add_datasource(name, url)::
-    deployment.mixin.spec.template.spec.withContainersMixin(
-      container.new("gfdatasource-%s" % name, $._images.gfdatasource) +
-      container.withArgs([
-        "--grafana-url=http://admin:admin@127.0.0.1:80/api",
-        "--data-source-url=%s" % url,
-        "--name=%s" % name,
-        "--type=prometheus",
-      ]) +
-      $.util.resourcesRequests("10m", "20Mi"),
-    ),
-
   grafana_deployment:
     deployment.new("grafana", 1, [$.grafana_container]) +
-    $.grafana_add_datasource("prometheus", "http://prometheus.%(namespace)s.svc.%(cluster_dns_suffix)s%(prometheus_web_route_prefix)s" % $._config) +
     $.util.configVolumeMount("grafana-config", "/etc/grafana") +
+    $.util.configVolumeMount("grafana-dashboard-provisioning", "/usr/share/grafana/conf/provisioning/dashboards") +
+    $.util.configVolumeMount("grafana-datasources", "/usr/share/grafana/conf/provisioning/datasources") +
     $.util.configVolumeMount("dashboards", "/grafana/dashboards"),
 
   grafana_service:


### PR DESCRIPTION
@msiuts this change will break your deployment; you need to update your remote storage override to match:

```
  grafana_datasource_config_map+:
    $.grafana_add_datasource("...", "..."),
```

This is because we're no longer using the side car to load in datasources, but the Grafana yaml provisioning.
