### PR TITLE
Set homepage to "." to allow deployment at any URL

### DIFF
--- a/promvt/package.json
+++ b/promvt/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/kausalco/public",
   "bugs": "https://github.com/kausalco/public/issues",
   "proxy": "http://localhost:9090",
+  "homepage": ".",
   "dependencies": {
     "d3-color": "^1.0.3",
     "d3-hierarchy": "^1.1.5",


### PR DESCRIPTION

This makes it so `yarn build` generates HTML with relative paths to the css / js files, which makes it easier to deploy somewhere without running the webpack-dev-server.