### PR TITLE
Include credentials in prometheus API fetches

### DIFF
--- a/promvt/src/Usage.js
+++ b/promvt/src/Usage.js
@@ -42,7 +42,7 @@ class Usage extends Component {
     if (this.props.request) {
       return this.props.request(url);
     }
-    return fetch(url);
+    return fetch(url,  { credentials: 'same-origin' });
   }
 
   getData(setState) {


### PR DESCRIPTION

I deployed promvt as a subfolder of the same domain I access prometheus from.  That subdomain was protected by an authentication mechanism.  I had to enable authentication on this `fetch` call so that promvt could load from the prometheus API from my browser.
