### PR TITLE
Add configVolumeMountSubPath util function

### DIFF
--- a/prometheus-ksonnet/lib/kausal.libsonnet
+++ b/prometheus-ksonnet/lib/kausal.libsonnet
@@ -284,11 +284,6 @@ k {
         volume.fromEmptyDir(name),
       ]),
 
-      deployment.mapContainers(addMount) +
-      deployment.mixin.spec.template.spec.withVolumesMixin([
-        volume.fromEmptyDir(name),
-      ]),
-
     manifestYaml(value):: (
       local f = std.native('manifestYamlFromJson');
       f(std.toString(value))

--- a/prometheus-ksonnet/lib/kausal.libsonnet
+++ b/prometheus-ksonnet/lib/kausal.libsonnet
@@ -233,6 +233,21 @@ k {
       deployment.mixin.spec.template.spec.withVolumesMixin([
         volume.fromConfigMap(name, name),
       ]),
+      
+    configVolumeMountSubPath(name, path, subpath)::
+      local container = $.core.v1.container,
+            deployment = $.extensions.v1beta1.deployment,
+            volumeMount = $.core.v1.volumeMount,
+            volume = $.core.v1.volume,
+            addMount(c) = c + container.withVolumeMountsMixin(
+        volumeMount.new(name, path) +
+        volumeMount.withSubPath(subpath)
+      );
+
+      deployment.mapContainers(addMount) +
+      deployment.mixin.spec.template.spec.withVolumesMixin([
+        volume.fromConfigMap(name, name),
+      ]),
 
     hostVolumeMount(name, hostPath, path)::
       local container = $.core.v1.container,

--- a/prometheus-ksonnet/lib/kausal.libsonnet
+++ b/prometheus-ksonnet/lib/kausal.libsonnet
@@ -219,29 +219,18 @@ k {
           ]),
       }
       else {},
-
-    configVolumeMount(name, path)::
-      local container = $.core.v1.container,
-            deployment = $.extensions.v1beta1.deployment,
-            volumeMount = $.core.v1.volumeMount,
-            volume = $.core.v1.volume,
-            addMount(c) = c + container.withVolumeMountsMixin(
-        volumeMount.new(name, path)
-      );
-
-      deployment.mapContainers(addMount) +
-      deployment.mixin.spec.template.spec.withVolumesMixin([
-        volume.fromConfigMap(name, name),
-      ]),
       
-    configVolumeMountSubPath(name, path, subpath)::
+    // VolumeMount helper functions can be augmented with mixins. 
+    // For example, passing "volumeMount.withSubPath(subpath)" will result in
+    // a subpath mixin.
+    configVolumeMount(name, path, volumeMountMixin={})::
       local container = $.core.v1.container,
             deployment = $.extensions.v1beta1.deployment,
             volumeMount = $.core.v1.volumeMount,
             volume = $.core.v1.volume,
             addMount(c) = c + container.withVolumeMountsMixin(
         volumeMount.new(name, path) +
-        volumeMount.withSubPath(subpath)
+        volumeMountMixin,
       );
 
       deployment.mapContainers(addMount) +
@@ -249,7 +238,7 @@ k {
         volume.fromConfigMap(name, name),
       ]),
 
-    hostVolumeMount(name, hostPath, path)::
+    hostVolumeMount(name, hostPath, path, volumeMountMixin={})::
       local container = $.core.v1.container,
             deployment = $.extensions.v1beta1.deployment,
             volumeMount = $.core.v1.volumeMount,
@@ -263,7 +252,7 @@ k {
         volume.fromHostPath(name, hostPath),
       ]),
 
-    secretVolumeMount(name, path, defaultMode=256)::
+    secretVolumeMount(name, path, defaultMode=256, volumeMountMixin={})::
       local container = $.core.v1.container,
             deployment = $.extensions.v1beta1.deployment,
             volumeMount = $.core.v1.volumeMount,
@@ -278,7 +267,7 @@ k {
         volume.mixin.secret.withDefaultMode(defaultMode),
       ]),
 
-    emptyVolumeMount(name, path)::
+    emptyVolumeMount(name, path, volumeMountMixin={})::
       local container = $.core.v1.container,
             deployment = $.extensions.v1beta1.deployment,
             volumeMount = $.core.v1.volumeMount,

--- a/prometheus-ksonnet/lib/kausal.libsonnet
+++ b/prometheus-ksonnet/lib/kausal.libsonnet
@@ -219,8 +219,8 @@ k {
           ]),
       }
       else {},
-      
-    // VolumeMount helper functions can be augmented with mixins. 
+
+    // VolumeMount helper functions can be augmented with mixins.
     // For example, passing "volumeMount.withSubPath(subpath)" will result in
     // a subpath mixin.
     configVolumeMount(name, path, volumeMountMixin={})::
@@ -244,7 +244,8 @@ k {
             volumeMount = $.core.v1.volumeMount,
             volume = $.core.v1.volume,
             addMount(c) = c + container.withVolumeMountsMixin(
-        volumeMount.new(name, path)
+        volumeMount.new(name, path) +
+        volumeMountMixin,
       );
 
       deployment.mapContainers(addMount) +
@@ -258,7 +259,8 @@ k {
             volumeMount = $.core.v1.volumeMount,
             volume = $.core.v1.volume,
             addMount(c) = c + container.withVolumeMountsMixin(
-        volumeMount.new(name, path)
+        volumeMount.new(name, path) +
+        volumeMountMixin,
       );
 
       deployment.mapContainers(addMount) +
@@ -273,8 +275,14 @@ k {
             volumeMount = $.core.v1.volumeMount,
             volume = $.core.v1.volume,
             addMount(c) = c + container.withVolumeMountsMixin(
-        volumeMount.new(name, path)
+        volumeMount.new(name, path) +
+        volumeMountMixin,
       );
+
+      deployment.mapContainers(addMount) +
+      deployment.mixin.spec.template.spec.withVolumesMixin([
+        volume.fromEmptyDir(name),
+      ]),
 
       deployment.mapContainers(addMount) +
       deployment.mixin.spec.template.spec.withVolumesMixin([


### PR DESCRIPTION
Gives user possibility of mounting configmap to a file in a directory rather than mounting the whole directory. e.g to /etc/config/config.file rather than to /etc/config/.

Is this something you would want? Would the better implementation be to have logic in configVolumeMount that uses subpath if there is a third argument (I'm not sure yet how to do that with jsonnet)?