### PR TITLE
update node_exporter job to have instance and nodename

### DIFF
--- a/prometheus-ksonnet/images.libsonnet
+++ b/prometheus-ksonnet/images.libsonnet
@@ -3,7 +3,7 @@
     prometheus: 'prom/prometheus:v2.2.1',
     watch: 'weaveworks/watch:master-5b2a6e5',
     kubeStateMetrics: 'gcr.io/google_containers/kube-state-metrics:v1.2.0',
-    grafana: 'grafana/grafana:5.0.4',
+    grafana: 'grafana/grafana:5.1.3',
     gfdatasource: 'quay.io/weaveworks/gfdatasource:master-2bda599',
     alertmanager: 'prom/alertmanager:v0.14.0',
     nodeExporter: 'prom/node-exporter:v0.15.2',

--- a/prometheus-ksonnet/lib/config.libsonnet
+++ b/prometheus-ksonnet/lib/config.libsonnet
@@ -35,7 +35,7 @@
 
     // Grafana config options.
     grafana_root_url: 'http://nginx.%(namespace)s.svc.%(cluster_dns_suffix)s/grafana' % self,
-    grafana_provisioning_dir: "/usr/share/grafana/conf/provisioning",
+    grafana_provisioning_dir: "/etc/grafana/provisioning",
 
     // Node exporter options.
     node_exporter_mount_root: true,
@@ -50,5 +50,6 @@
     kubeControllerManagerSelector: 'job="kube-system/kube-controller-manager"',
     kubeApiserverSelector: 'job="kube-system/kube-apiserver"',
     podLabel: 'instance',
+    grafanaPrefix: '/grafana',
   },
 }

--- a/prometheus-ksonnet/lib/grafana.libsonnet
+++ b/prometheus-ksonnet/lib/grafana.libsonnet
@@ -102,7 +102,7 @@
     container.new('grafana', $._images.grafana) +
     container.withPorts($.core.v1.containerPort.new('grafana', 80)) +
     container.withCommand([
-      '/usr/sbin/grafana-server',
+      '/usr/share/grafana/bin/grafana-server',
       '--homepath=/usr/share/grafana',
       '--config=/etc/grafana-config/grafana.ini',
     ]) +
@@ -112,6 +112,7 @@
 
   grafana_deployment:
     deployment.new('grafana', 1, [$.grafana_container]) +
+    deployment.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
     $.util.configVolumeMount('grafana-config', '/etc/grafana-config') +
     $.util.configVolumeMount('grafana-dashboard-provisioning', '%(grafana_provisioning_dir)s/dashboards' % $._config) +
     $.util.configVolumeMount('grafana-datasources', '%(grafana_provisioning_dir)s/datasources' % $._config) +

--- a/prometheus-ksonnet/lib/kausal.libsonnet
+++ b/prometheus-ksonnet/lib/kausal.libsonnet
@@ -100,6 +100,11 @@ k {
         // handing around.
         super.mixin.spec.withRevisionHistoryLimit(10),
     },
+    
+    statefulSet+: {
+      new(name, replicas, containers, volumeClaims, podLabels={})::
+        super.new(name, replicas, containers, volumeClaims, podLabels { name: name })
+    },
   },
 
   extensions+: {

--- a/prometheus-ksonnet/lib/prometheus-config.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus-config.libsonnet
@@ -163,14 +163,19 @@
             regex: 'kube-state-metrics',
             action: 'keep',
           },
-
           // Rename instances to be the pod name
           {
             source_labels: ['__meta_kubernetes_pod_name'],
             action: 'replace',
             target_label: 'instance',
           },
-        ],
+          // Rename node to be the node name.
+          {
+            source_labels: ['__meta_kubernetes_pod_node_name'],
+            action: 'replace',
+            target_label: 'node',
+          },
+        ],  
       },
 
       // A separate scrape config for node-exporter which maps the nodename onto the

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -59,6 +59,7 @@
       deployment.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
       if $._config.enable_rbac
       then deployment.mixin.spec.template.spec.withServiceAccount('prometheus')
+      else {}
     ),
 
   local pvc = $.core.v1.persistentVolumeClaim,
@@ -80,18 +81,19 @@
    if ! $._config.stateful
    then {}
    else (
-     statefulset.new('prometheus', 1, [
-       $.prometheus_container.withVolumeMountsMixin(
-         volumeMount.new('prometheus-data', '/prometheus')
-       ),
-       $.prometheus_watch_container,
-     ], $.prometheus_pvc) +
-     $.util.configVolumeMount('prometheus-config', '/etc/prometheus') +
-     statefulset.mixin.spec.withServiceName('prometheus') +
-     statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
-     statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
-     if $._config.enable_rbac
-     then statefulset.mixin.spec.template.spec.withServiceAccount('prometheus')
+    statefulset.new('prometheus', 1, [
+      $.prometheus_container.withVolumeMountsMixin(
+        volumeMount.new('prometheus-data', '/prometheus')
+      ),
+      $.prometheus_watch_container,
+    ], $.prometheus_pvc) +
+    $.util.configVolumeMount('prometheus-config', '/etc/prometheus') +
+    statefulset.mixin.spec.withServiceName('prometheus') +
+    statefulset.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.prometheus_web_route_prefix }) +
+    statefulset.mixin.spec.template.spec.securityContext.withRunAsUser(0) +
+    if $._config.enable_rbac
+    then statefulset.mixin.spec.template.spec.withServiceAccount('prometheus')
+    else {}
     ),
 
   prometheus_service:


### PR DESCRIPTION
This PR reverts the instance label on the node exporter job to the pod name and adds a node label with the name of the node. This fixes the following rule which currently is not being evaluated correctly.

```
{
  record: 'node:node_num_cpu:sum',
  expr: |||
    count by (node) (sum by (node, cpu) (
      node_cpu{%(nodeExporterSelector)s}
    * on (namespace, %(podLabel)s) group_left(node)
      node_namespace_pod:kube_pod_info:
   ))
}
```