### PR TITLE
Move AM config file away from the working directory

### DIFF
--- a/prometheus-ksonnet/lib/alertmanager.libsonnet
+++ b/prometheus-ksonnet/lib/alertmanager.libsonnet
@@ -30,7 +30,7 @@
     container.withPorts($.core.v1.containerPort.new('http-metrics', $._config.alertmanager_port)) +
     container.withArgs([
       '--log.level=info',
-      '--config.file=/etc/alertmanager/alertmanager.yml',
+      '--config.file=/etc/alertmanager/config/alertmanager.yml',
       '--web.listen-address=:%s' % $._config.alertmanager_port,
       '--web.external-url=%s%s' % [$._config.alertmanager_external_hostname, $._config.alertmanager_path],
     ]) +
@@ -44,7 +44,7 @@
     container.withArgs([
       '-v',
       '-t',
-      '-p=/etc/alertmanager',
+      '-p=/etc/alertmanager/config',
       'curl',
       '-X',
       'POST',
@@ -67,7 +67,7 @@
       $.alertmanager_watch_container,
     ]) +
     deployment.mixin.spec.template.metadata.withAnnotations({ 'prometheus.io.path': '%smetrics' % $._config.alertmanager_path }) +
-    $.util.configVolumeMount('alertmanager-config', '/etc/alertmanager'),
+    $.util.configVolumeMount('alertmanager-config', '/etc/alertmanager/config'),
 
   alertmanager_service:
     $.util.serviceFor($.alertmanager_deployment),

--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -66,7 +66,7 @@
       containerPort.new('self-metrics', 81),
     ]) +
     $.util.resourcesRequests('25m', '20Mi') +
-    $.util.resourcesLimits('50m', '40Mi'),
+    $.util.resourcesLimits('50m', '60Mi'),
 
   local deployment = $.apps.v1beta1.deployment,
 


### PR DESCRIPTION
0.15 made /etc/alertmanager the working directory, where
the data folder is attempted to be created. So the current structure
fails with:

level=error ts=2018-07-11T11:33:30.375587912Z caller=main.go:179 msg="Unable to create data directory" err="mkdir data/: read-only file system"

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>