### PR TITLE
Bump node_exporter and k-s-metrics limits

### DIFF
--- a/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
+++ b/prometheus-ksonnet/lib/kube-state-metrics.libsonnet
@@ -66,7 +66,7 @@
       containerPort.new('self-metrics', 81),
     ]) +
     $.util.resourcesRequests('25m', '20Mi') +
-    $.util.resourcesLimits('50m', '60Mi'),
+    $.util.resourcesLimits('100m', '60Mi'),
 
   local deployment = $.apps.v1beta1.deployment,
 

--- a/prometheus-ksonnet/lib/node-exporter.libsonnet
+++ b/prometheus-ksonnet/lib/node-exporter.libsonnet
@@ -12,7 +12,7 @@
     container.mixin.securityContext.withPrivileged(true) +
     container.mixin.securityContext.withRunAsUser(0) +
     $.util.resourcesRequests('10m', '20Mi') +
-    $.util.resourcesLimits('20m', '40Mi'),
+    $.util.resourcesLimits('50m', '40Mi'),
 
   local daemonSet = $.extensions.v1beta1.daemonSet,
 


### PR DESCRIPTION
* We're seeing heavy throttling on medium sized clusters

@tomwilkie 