### PR TITLE
remove env value if value is empty

### DIFF
--- a/grafana-builder/grafana.libsonnet
+++ b/grafana-builder/grafana.libsonnet
@@ -313,9 +313,9 @@
         intervalFactor: 2,
         legendFormat: '',
         step: 10,
-        refId: std.char(65+i),
+        refId: std.char(65 + i),
       }
-      for i in std.range(0, std.length(qs)-1)
+      for i in std.range(0, std.length(qs) - 1)
     ],
   },
 

--- a/prometheus-ksonnet/lib/nginx.libsonnet
+++ b/prometheus-ksonnet/lib/nginx.libsonnet
@@ -83,7 +83,7 @@
   local oauth2_proxy = import 'oauth2_proxy/oauth2-proxy.libsonnet',
 
   oauth2_proxy:
-    if ! $._config.oauth_enabled
+    if !$._config.oauth_enabled
     then {}
     else oauth2_proxy {
       _config+:: $._config {

--- a/prometheus-ksonnet/lib/prometheus.libsonnet
+++ b/prometheus-ksonnet/lib/prometheus.libsonnet
@@ -65,7 +65,7 @@
   local pvc = $.core.v1.persistentVolumeClaim,
 
   prometheus_pvc::
-    if ! $._config.stateful
+    if !$._config.stateful
     then {}
     else (
       pvc.new() +
@@ -78,7 +78,7 @@
   local volumeMount = $.core.v1.volumeMount,
 
   prometheus_statefulset:
-    if ! $._config.stateful
+    if !$._config.stateful
     then {}
     else (
       statefulset.new('prometheus', 1, [


### PR DESCRIPTION
When an envvar is declared with an empty value k8s will remove it automatically, so then it will always show up as a difference on ks diff:

```
               {
                 "name": "CLUSTER_SIZE",
                 "value": "3"
               },
               {
                 "name": "BOOTSTRAP_NODES"
+                "value": ""
               },
               {
                 "name": "OFFSET",
                 "value": "200000000"
               },
```

With this change ksonnet will remove the empty value property, so there's no difference:

```
               {
                 "name": "CLUSTER_SIZE",
                 "value": "3"
               },
               {
                 "name": "BOOTSTRAP_NODES"
               },
               {
                 "name": "OFFSET",
                 "value": "200000000"
               },
```