### PR TITLE
do not set properties in pvc.new()

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -48,6 +48,10 @@ k {
           else {},
       },
 
+      persistentVolumeClaim+:: {
+        new():: {},
+      },
+
       container:: $.extensions.v1beta1.deployment.mixin.spec.template.spec.containersType {
         new(name, image)::
           super.new(name, image) +


### PR DESCRIPTION
without this change `.new()` sets the two properties `apiVersion` & `kind`. both of those properties get removed by k8s, so they then show up as differences:

```
     "volumeClaimTemplates": [
       {
         "metadata": {
           "name": "data"
         },
         "spec": {
           "accessModes": [
             "ReadWriteOnce"
           ],
           "resources": {
             "requests": {
               "storage": "10Gi"
             }
           },
           "storageClassName": "zookeeper"
         }
+        "apiVersion": "v1"
+        "kind": "PersistentVolumeClaim"
       }
     ]
```

with this change those differences do not show up anymore.