### PR TITLE
reuse withEnvMixin override

### DIFF
--- a/ksonnet-util/kausal.libsonnet
+++ b/ksonnet-util/kausal.libsonnet
@@ -76,7 +76,7 @@ k {
           ]),
 
         withEnvMap(es)::
-          super.withEnvMixin([
+          self.withEnvMixin([
             $.core.v1.container.envType.new(k, es[k])
             for k in std.objectFields(es)
           ]),


### PR DESCRIPTION
we might as well use that change in `withEnvMap`